### PR TITLE
Add maven gpg plugin version to appease mvn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>


### PR DESCRIPTION
```
[WARNING] Some problems were encountered while building the effective model for hll:hll:jar:1.7.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-gpg-plugin is missing. @ line 68, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

cc @hll/maintainers 
