### PR TITLE
quick fix for javadoc on jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <additionalJOption>-Xdoclint:none</additionalJOption>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Apparently JDK8 no longer allows [self-closing HTML elelements](http://stackoverflow.com/questions/26049329/javadoc-in-jdk-8-invalid-self-closing-element-not-allowed). To keep people's builds from mysteriously breaking, let's tell JDK8 to ignore that for now.
